### PR TITLE
Fix usage with --production flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The client-side SDK targets ECMAScript5+ compatible browsers.
 
 ```html
 <script
-src="https://cdn.virgilsecurity.com/packages/javascript/sdk/4.5.0/virgil-sdk.min.js"
+src="https://cdn.virgilsecurity.com/packages/javascript/sdk/4.5.1/virgil-sdk.min.js"
 crossorigin="anonymous"></script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgil-sdk",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Virgil Security Services SDK",
   "contributors": [
     "Eugene Baranov <ebaranov.dev@gmail.com> (https://github.com/ebaranov/)",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "virgil-crypto": "2.1.0",
-    "to-arraybuffer": "^1.0.1"
+    "to-arraybuffer": "^1.0.1",
+    "is-buffer": "^1.1.4"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",
@@ -54,7 +55,6 @@
     "gulp-changed": "^1.3.0",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.0.1",
-    "is-buffer": "^1.1.4",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.4",
     "script-loader": "^0.6.1",


### PR DESCRIPTION
Moved "is-buffer" module from "devDependencies" to "dependencies" in package.json. It wasn't included when the virgil-sdk package was installed with `--production` flag causing subsequent `require(''virgil-sdk)` in Node.js to fail.