### PR TITLE
Allow updating entries in KeyEntryStorage

### DIFF
--- a/src/Sdk/Lib/KeyStorage/IKeyEntryStorage.ts
+++ b/src/Sdk/Lib/KeyStorage/IKeyEntryStorage.ts
@@ -1,5 +1,7 @@
 import { IStorageAdapter } from './adapters/IStorageAdapter';
 
+export type KeyEntryMeta = { [key: string]: string };
+
 export interface IKeyEntryStorageConfig {
 	dir?: string;
 	name?: string;
@@ -9,13 +11,26 @@ export interface IKeyEntryStorageConfig {
 export interface IKeyEntry {
 	name: string;
 	value: Buffer;
-	meta?: { [key: string]: string };
+	meta?: KeyEntryMeta;
+	creationDate: Date;
+	modificationDate: Date;
+}
+
+export interface ISaveKeyEntryParams {
+	value: Buffer;
+	meta?: KeyEntryMeta;
+}
+
+export interface IUpdateKeyEntryParams {
+	value?: Buffer;
+	meta?: KeyEntryMeta;
 }
 
 export interface IKeyEntryStorage {
-	save (keyEntry: IKeyEntry): Promise<void>;
+	save (name: string, params: ISaveKeyEntryParams): Promise<IKeyEntry>;
 	load (name: string): Promise<IKeyEntry|null>;
 	exists (name: string): Promise<boolean>;
 	remove (name: string): Promise<boolean>;
 	list (): Promise<IKeyEntry[]>;
+	update (name: string, params: IUpdateKeyEntryParams): Promise<IKeyEntry>;
 }

--- a/src/Sdk/Lib/KeyStorage/KeyEntryAlreadyExistsError.ts
+++ b/src/Sdk/Lib/KeyStorage/KeyEntryAlreadyExistsError.ts
@@ -1,0 +1,10 @@
+import { VirgilError } from '../VirgilError';
+
+export class KeyEntryAlreadyExistsError extends VirgilError {
+	constructor(name?: string) {
+		super(
+			`Key entry ${ name ? 'named ' + name : 'with same name' }already exists`,
+			'KeyEntryAlreadyExistsError'
+		);
+	}
+}

--- a/src/Sdk/Lib/KeyStorage/KeyEntryDoesNotExistError.ts
+++ b/src/Sdk/Lib/KeyStorage/KeyEntryDoesNotExistError.ts
@@ -1,0 +1,10 @@
+import { VirgilError } from '../VirgilError';
+
+export class KeyEntryDoesNotExistError extends VirgilError {
+	constructor(name: string) {
+		super(
+			`Key entry ${ name ? 'named ' + name : 'with the given name'} does not exist.`,
+			'KeyEntryDoesNotExistError'
+		);
+	}
+}

--- a/src/Sdk/Lib/KeyStorage/StorageEntryAlreadyExistsError.ts
+++ b/src/Sdk/Lib/KeyStorage/StorageEntryAlreadyExistsError.ts
@@ -1,0 +1,10 @@
+import { VirgilError } from '../VirgilError';
+
+export class StorageEntryAlreadyExistsError extends VirgilError {
+	constructor(key?: string) {
+		super(
+			`Storage entry ${ key ? 'with key ' + name : 'with the given key' }already exists`,
+			'StorageEntryAlreadyExistsError'
+		);
+	}
+}

--- a/src/Sdk/Lib/KeyStorage/adapters/FileSystemStorageAdapter.ts
+++ b/src/Sdk/Lib/KeyStorage/adapters/FileSystemStorageAdapter.ts
@@ -1,12 +1,13 @@
-import { IStorageAdapter, IStorageAdapterConfig } from './IStorageAdapter';
-
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
+import { IStorageAdapter, IStorageAdapterConfig } from './IStorageAdapter';
+import { StorageEntryAlreadyExistsError } from '../StorageEntryAlreadyExistsError';
 
 const NO_SUCH_FILE = 'ENOENT';
+const FILE_EXISTS = 'EEXIST';
 
 export default class FileSystemStorageAdapter implements IStorageAdapter {
 
@@ -23,8 +24,8 @@ export default class FileSystemStorageAdapter implements IStorageAdapter {
 			const file = this.resolveFilePath(key);
 
 			fs.writeFile(file, data, { flag: 'wx' }, err => {
-				if (err) {
-					return reject(err);
+				if (err && err.code === FILE_EXISTS) {
+					return reject(new StorageEntryAlreadyExistsError());
 				}
 
 				resolve();

--- a/src/Sdk/Lib/KeyStorage/adapters/FileSystemStorageAdapter.ts
+++ b/src/Sdk/Lib/KeyStorage/adapters/FileSystemStorageAdapter.ts
@@ -73,6 +73,19 @@ export default class FileSystemStorageAdapter implements IStorageAdapter {
 		});
 	}
 
+	update (key: string, data: Buffer): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const file = this.resolveFilePath(key);
+			fs.writeFile(file, data, { flag: 'w' }, err => {
+				if (err) {
+					return reject(err);
+				}
+
+				resolve();
+			});
+		});
+	}
+
 	clear (): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			rimraf(this.config.dir!, err => {

--- a/src/Sdk/Lib/KeyStorage/adapters/IStorageAdapter.ts
+++ b/src/Sdk/Lib/KeyStorage/adapters/IStorageAdapter.ts
@@ -8,6 +8,7 @@ export interface IStorageAdapter {
 	load (key: string): Promise<Buffer|null>;
 	exists (key: string): Promise<boolean>;
 	remove (key: string): Promise<boolean>;
+	update (key: string, data: Buffer): Promise<void>;
 	clear (): Promise<void>;
 	list (): Promise<Buffer[]>;
 }

--- a/src/Sdk/Lib/KeyStorage/adapters/IndexedDbStorageAdapter.ts
+++ b/src/Sdk/Lib/KeyStorage/adapters/IndexedDbStorageAdapter.ts
@@ -208,6 +208,34 @@ export default class IndexedDbStorageAdapter implements IStorageAdapter {
 		});
 	}
 
+	update (key: string, data: Buffer): Promise<void> {
+		key = normalizeKey(key);
+		return new Promise((resolve, reject) => {
+			this.ready().then(() => {
+				createTransaction(this._dbInfo!, READ_WRITE, (err, transaction ) => {
+					if (err) {
+						return reject(err);
+					}
+
+					try {
+						const store = transaction!.objectStore(this._dbInfo!.storeName!);
+						const req = store.put(toArrayBuffer(data), key);
+
+						req.onsuccess = () => {
+							resolve();
+						};
+
+						req.onerror = () => {
+							reject(req.error);
+						};
+					} catch (error) {
+						reject(error);
+					}
+				});
+			}).catch(reject);
+		});
+	}
+
 	clear(): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			this.ready().then(() => {

--- a/src/Sdk/Lib/PrivateKeyStorage.ts
+++ b/src/Sdk/Lib/PrivateKeyStorage.ts
@@ -16,11 +16,10 @@ export class PrivateKeyStorage {
 
 	store (name: string, privateKey: IPrivateKey, meta?: { [key: string]: string }) {
 		const privateKeyData = this.privateKeyExporter.exportPrivateKey(privateKey);
-		return this.storageBackend.save({
+		return this.storageBackend.save(
 			name,
-			value: privateKeyData,
-			meta
-		});
+			{ value: privateKeyData, meta }
+		);
 	}
 
 	load (name: string): Promise<IPrivateKeyEntry|null> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export * from './Sdk/CardVerifier';
 export * from './Sdk/Web/RawSignedModel';
 export * from './Sdk/Web/ModelSigner';
 export * from './Sdk/Lib/KeyStorage/KeyStorage';
+export * from './Sdk/Lib/KeyStorage/StorageEntryAlreadyExistsError';
 export * from './Sdk/Lib/KeyStorage/KeyEntryStorage';
 export * from './Sdk/Lib/PrivateKeyStorage';

--- a/src/tests/unit/PrivateKeyStorage.test.ts
+++ b/src/tests/unit/PrivateKeyStorage.test.ts
@@ -25,10 +25,11 @@ describe ('PrivateKeyStorage', () => {
 			return privateKeyStorage.store('test', {}, { meta: 'data' })
 				.then(() => {
 					assert.isTrue(storageBackendStub.save.calledOnce);
-					const storedEntry = storageBackendStub.save.firstCall.args[0];
-					assert.equal(storedEntry.name, 'test');
-					assert.equal(storedEntry.value.toString(), 'private_key');
-					assert.deepEqual(storedEntry.meta, { meta: 'data' });
+					const entryName = storageBackendStub.save.firstCall.args[0];
+					const entry = storageBackendStub.save.firstCall.args[1];
+					assert.equal(entryName, 'test');
+					assert.equal(entry.value.toString(), 'private_key');
+					assert.deepEqual(entry.meta, { meta: 'data' });
 				});
 		});
 	});

--- a/src/tests/unit/StorageAdapter.test.ts
+++ b/src/tests/unit/StorageAdapter.test.ts
@@ -196,4 +196,23 @@ describe ('StorageAdapter', () => {
 			assert.sameDeepMembers(entries, expectedEntries);
 		})
 	});
+
+	it('update with existing key', () => {
+		return storage.store('one', Buffer.from('one'))
+			.then(() => storage.update('one', Buffer.from('another_one')))
+			.then(() => storage.load('one'))
+			.then(result => {
+				assert.isNotNull(result);
+				assert.equal(result!.toString(), 'another_one');
+			});
+	});
+
+	it('update with non-existing key creates new entry', () => {
+		return storage.update('nonexistent', Buffer.from('value'))
+			.then(() => storage.load('nonexistent'))
+			.then(result => {
+				assert.isNotNull(result);
+				assert.equal(result!.toString(), 'value');
+			});
+	});
 });

--- a/src/tests/unit/StorageAdapter.test.ts
+++ b/src/tests/unit/StorageAdapter.test.ts
@@ -1,4 +1,5 @@
 import StorageAdapter from '../../Sdk/Lib/KeyStorage/adapters/FileSystemStorageAdapter';
+import { StorageEntryAlreadyExistsError } from '../../Sdk/Lib/KeyStorage/StorageEntryAlreadyExistsError';
 
 describe ('StorageAdapter', () => {
 	let storage: StorageAdapter;
@@ -14,7 +15,7 @@ describe ('StorageAdapter', () => {
 		return storage.clear();
 	});
 
-	it('set and get the key', () => {
+	it('store and get the key', () => {
 		const expected = Buffer.from('one');
 		return assert.eventually.equal(
 			storage.store('first', expected)
@@ -31,7 +32,7 @@ describe ('StorageAdapter', () => {
 		return assert.isRejected(
 			storage.store('first', Buffer.from('one'))
 				.then(() => storage.store('first', Buffer.from('two'))),
-			Error,
+			StorageEntryAlreadyExistsError,
 			'already exists'
 		);
 	});
@@ -49,7 +50,7 @@ describe ('StorageAdapter', () => {
 		);
 	});
 
-	it('set remove set', () => {
+	it('store remove store', () => {
 		return assert.eventually.isTrue(
 			storage.store('first', Buffer.from('one'))
 				.then(() => storage.remove('first'))
@@ -67,7 +68,7 @@ describe ('StorageAdapter', () => {
 		);
 	});
 
-	it('set two items', () => {
+	it('store two items', () => {
 		const oneExpected = Buffer.from('one');
 		const twoExpected = Buffer.from('two');
 		return assert.becomes(
@@ -88,7 +89,7 @@ describe ('StorageAdapter', () => {
 		);
 	});
 
-	it('set remove three items', () => {
+	it('store remove three items', () => {
 		return assert.eventually.isNull(
 			Promise.all([
 				storage.store('first', Buffer.from('one')),
@@ -121,7 +122,7 @@ describe ('StorageAdapter', () => {
 		);
 	});
 
-	it('set empty value', () => {
+	it('store empty value', () => {
 		return assert.eventually.isTrue(
 			storage.store('first', new Buffer(0))
 				.then(() => storage.load('first'))
@@ -129,7 +130,7 @@ describe ('StorageAdapter', () => {
 		);
 	});
 
-	it('set with weird keys', () => {
+	it('store with weird keys', () => {
 		return assert.becomes(
 			Promise.all([
 				storage.store(' ', Buffer.from('space')),


### PR DESCRIPTION
### IKeyEntry
* Added `creationDate` and `modificationDate` properties of type Date. These props are set automatically by the `KeyEntryStorage#save` method. The `modificationDate` is updated by the `KeyEntryStorage#update` method. 

### KeyEntryStorage
* Added `update` method.
* Changed signature of `save` method to `save (name: string, params: { value: Buffer, meta: Object<string, string>})` to match the signature of the `update`.

### IStorageAdapter
* Added `update` method.
* Require `store` method to throw error with name property equal to `'StorageEntryAlreadyExistsError'` to indicate that the value for the given key already exists in the storage.