### PR TITLE
Fix incorrect method call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ import { CachingJwtProvider, CardManager, PrivateKeyStorage, VirgilCardVerifier 
 	const keyPair = virgilCrypto.generateKeys();
 
 	// Store the private key
-	await privateKeyStorage.save('alice_private_key', keyPair.privateKey);
+	await privateKeyStorage.store('alice_private_key', keyPair.privateKey);
 
 	// Publish user's card on the Cards Service
 	const card = await cardManager.publishCard({


### PR DESCRIPTION
In the README, a call is made to save() from privateKeyStorage. This method call should be store().

I wanted to post this to the [Developer Portal](https://virgilsecurity.com/docs) but it returns a 404.