### PR TITLE
6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgil-sdk",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "Virgil Security Services SDK",
   "contributors": [
     "Eugene Baranov <ebaranov.dev@gmail.com> (https://github.com/ebaranov/)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './Cards/ModelSigner';
 export * from './Client/VirgilAgent';
 export * from './Storage/adapters/DefaultStorageAdapter';
 export * from './Storage/adapters/errors';
+export { IStorageAdapter } from './Storage/adapters/IStorageAdapter';
 export * from './Storage/KeyStorage';
 export * from './Storage/KeyEntryStorage/KeyEntryStorage';
 export * from './Storage/KeyEntryStorage/errors';


### PR DESCRIPTION
What's new:
- Make `IStorageAdapter` public. This will simplify the update process of [React Native storage](https://github.com/VirgilSecurity/virgil-key-storage-rn) and creation of new storages.