### PR TITLE
update fetch-ponyfill so node/webpack envs work

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/utf8": "^2.1.6",
     "@virgilsecurity/crypto-types": "^1.0.0",
     "base-64": "^0.1.0",
-    "fetch-ponyfill": "^6.0.2",
+    "fetch-ponyfill": "^6.1.1",
     "mkdirp": "^1.0.3",
     "rimraf": "^3.0.2",
     "utf8": "^3.0.0",


### PR DESCRIPTION
fetch-ponyfill didn't properly support environments using webpack & nodejs (which electron does) until version 6.1.1.